### PR TITLE
owm2ffmap.py: python3 compatibility

### DIFF
--- a/owm2ffmap/owm2ffmap.py
+++ b/owm2ffmap/owm2ffmap.py
@@ -308,7 +308,7 @@ if __name__ == "__main__":
         brokenlinks.append(link)
     graphlinks = [link for link in graphlinks if link not in brokenlinks]
 
-    graphnodes = [node for _, node in graphnodes.iteritems()]
+    graphnodes = [node for _, node in graphnodes.items()]
     graphnodes = sorted(graphnodes, key=lambda x: x["seq"])
     graph = {"batadv": {"directed": False, "graph": [], "links": graphlinks, "multigraph": False, "nodes": graphnodes}, "version": 1}
     print(graph)

--- a/owm2ffmap/requirements.txt
+++ b/owm2ffmap/requirements.txt
@@ -1,3 +1,6 @@
-tornado
+tornado 5.x 
+# we explicitly need a tornado version from 5.x branch! In more recent versions the 
+# callback-argument from httpclient.AsyncHTTPClient.fetch() is removed, which needs
+# a new implementation of the handle_request() function using more modern async.io system.
 diskcache
 python-dateutil


### PR DESCRIPTION
This commit will change the method .iteritems (python2 and not supported anymore) to its python3 pendant.