### PR TITLE
owm2ffmap.py: Adjust the boundary box for fetching node-data from owm.

### DIFF
--- a/owm2ffmap/owm2ffmap.py
+++ b/owm2ffmap/owm2ffmap.py
@@ -32,7 +32,7 @@ firmware_pre020_dev  = re.compile("^Freifunk[ -]Berlin kathleen 0\.[0-2]\.[0-2][
 firmware_kathleen1505 = re.compile("^Freifunk Berlin kathleen 15.05(\.1){0,1}$")
 firmware_openwrt = re.compile("^OpenWrt .*")
 
-bounding_box = "12.9,52.27,13.8,52.7"  # Berlin
+bounding_box = "12.9,52.27,14.12,52.7"  # Berlin and parts of East-Brandenburg (-> Fuerstenwalde)
 bounding_box_elems = [float(x) for x in bounding_box.split(",")]
 
 


### PR DESCRIPTION
This commit will include some parts of East Brandenburg into the map. Main goal is to include the nodes of Fürstenwalde, which currently has not the resources to host an own independent map.

@sarumpaet Is that okay for you? I'd like to have this merged rather quickly, as we currently have no map, we can look our nodes after.