### PR TITLE
remove broken references to owm-map / owm-api

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,6 @@ https://hopglass.berlin.freifunk.net
 
 ...runs an instance of HopGlass
 https://github.com/plumpudding/hopglass
-that gets its data from OpenWifiMap.net using a simple converter
-(found in owm2ffmap/).
+as our primary map.
+
+The OWM-script (see freifunk-berlin/packages) on the node uploads the data via util.berlin.freifunk.net to store them in a local folder.

--- a/www/config.json
+++ b/www/config.json
@@ -29,11 +29,6 @@
   ],
   "nodeInfos": [
     {
-      "name" : "OpenWifiMap",
-      "href" : "https://util.berlin.freifunk.net/knoteninfo?knoten={NODE_ID}&typ=owm",
-      "caption" : "{NODE_ID} auf openwifimap.net"
-    },
-    {
       "name" : "monitor.berlin.freifunk.net",
       "href" : "https://util.berlin.freifunk.net/knoteninfo?knoten={NODE_ID}&typ=monitor",
       "caption" : "{NODE_ID} auf monitor.berlin.freifunk.net"


### PR DESCRIPTION
As of https://github.com/orgs/freifunk-berlin/projects/1 we can drop
* the OWM-link from the nodes details-page (currently it will reference back to hopglass)
* ~~the convertor for data pulled from OWM-API~~ dropped this commit based on https://github.com/freifunk-berlin/hopglass.berlin.freifunk.net/issues/11#issuecomment-748686342